### PR TITLE
feat: Drop support for python 3.6 and add the same for django 41

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,6 @@ jobs:
       max-parallel: 5
       matrix:
         python-version:
-          - 3.6
           - 3.7
           - 3.8
           - 3.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,11 +20,11 @@ classifiers =
     Framework :: Django :: 3.1
     Framework :: Django :: 3.2
     Framework :: Django :: 4.0
+    Framework :: Django :: 4.1
     Intended Audience :: Developers
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Programming Language :: Python
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -36,7 +36,7 @@ keywords = django dogs status-codes status
 [options]
 packages = find:
 include_package_data = True
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires = django
 zip_safe = False
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,13 @@
 [tox]
 envlist =
-    py36-dj{22, 30, 31, 32}
     py37-dj{22, 30, 31, 32}
-    py38-dj{22, 30, 31, 32, 40, main}
-    py39-dj{22, 30, 31, 32, 40, main}
-    py310-dj{40, main}
+    py38-dj{22, 30, 31, 32, 40, 41, main}
+    py39-dj{22, 30, 31, 32, 40, 41, main}
+    py310-dj{40, 41, main}
     lint
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39
@@ -29,6 +27,7 @@ deps =
     dj31: Django>=3.1,<3.2
     dj32: Django>=3.2,<3.3
     dj40: Django>=4.0,<4.1
+    dj41: Django>=4.1,<4.2
     djmain: https://github.com/django/django/archive/main.tar.gz
 
 usedevelop = True
@@ -37,3 +36,12 @@ commands =
     python -W error::DeprecationWarning -W error::PendingDeprecationWarning -m coverage run --parallel-mode -m pytest {posargs}
 setenv =
     PYTHONDONTWRITEBYTECODE=1
+
+[testenv:py38-djmain]
+ignore_outcome = true
+
+[testenv:py39-djmain]
+ignore_outcome = true
+
+[testenv:py310-djmain]
+ignore_outcome = true


### PR DESCRIPTION
- since python 3.6 had reached its end of life pretty long
  back, we can safely remove its support.